### PR TITLE
Ignore issues if they are disabled

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -153,6 +153,10 @@ Repo.prototype.getIssues = function (callback) {
     github.getIssues(this.data.owner.login, this.data.name, function (err, issues) {
         if (err) return callback(err);
 
+        if (!issues[0].pull_request) {
+            issues = [];
+        }
+
         this.issues = issues
             .map(function (issue) { return !issue.pull_request.html_url && issue  })
             .filter(function (issue) { return issue });


### PR DESCRIPTION
Some repos have issues disabled (being managed outside of github) but still want to haunt pull requests. This PR will ignore issues if they are disabled.

Here is the error I received on a repo that has issues disabled:

```
/var/www/haunt/lib/repo.js:158
            .map(function (issue) { return !issue.pull_request.html_url && iss
                                                              ^
TypeError: Cannot read property 'html_url' of undefined
    at Repo.getIssues (/var/www/haunt/lib/repo.js:158:63)
```

and the contents of `issues`: `[ { message: 'Issues are disabled for this repo' } ]`

Thanks!
