### PR TITLE
Add commentOnDiff method

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ When testing pull-requests, your function will be passed an object with the foll
 + issue.files[*].status - the status of the file (modified, deleted, etc.)
 + issue.files[*].changes - the number of changes made in a file
 + issue.files[*].deletions - the number of deletions made in a file
++ issue.files[*].comments - an array of line comments on the file
 + issue.commits - an array of git commits
 + issue.commits[*].sha - the commit sha
 + issue.commits[*].commit - a commit object
@@ -217,4 +218,5 @@ The following convenience methods are made available on all haunt objects. You c
 + issue.assign - (accepts a username) assigns an issue/pull-request
 + issue.comment - (accepts a string) comments on an issue/pull-request
 + issue.files[*].comment - (accepts an comment and line number) comment on a given line number in a diff of a pull-request
++ issue.files[*].comments[*].reply - (accepts a string) reply to a comment in a diff on a pull request
 + issue.reportFailures - generic test failure message, which notifies a user what failed based on mocha reporter.

--- a/README.md
+++ b/README.md
@@ -216,4 +216,5 @@ The following convenience methods are made available on all haunt objects. You c
 + issue.close - closes an issue/pull-request
 + issue.assign - (accepts a username) assigns an issue/pull-request
 + issue.comment - (accepts a string) comments on an issue/pull-request
++ issue.files[*].comment - (accepts an comment and line number) comment on a given line number in a diff of a pull-request
 + issue.reportFailures - generic test failure message, which notifies a user what failed based on mocha reporter.

--- a/examples/comment-on-diff.js
+++ b/examples/comment-on-diff.js
@@ -1,0 +1,43 @@
+// COMMENT ON DIFF EXAMPLE
+// =======================
+
+var assert = require('assert');
+
+module.exports = {
+
+    'pull-requests': {
+
+        'should not use deprecated path.exists(Sync)': function (pull) {
+            pull.files.forEach(function (file) {
+                findOnLine(/path\.exists|path\.existsSync/, file.patch, function(err, lineNum) {
+
+                    file.comment(
+                        'Yo dude path.exists(Sync) has been deprecated in nodejs v0.8, use fs.exists(Sync) instead.',
+                        lineNum
+                    )
+
+                })
+            })
+        }
+
+    }
+
+}
+
+// find stuff in a diff and return the line number
+function findOnLine(find, patch, cb) {
+    if (find.test(patch)) {
+        var lineNum = 0
+        patch.split('\n').forEach(function(line) {
+            var range = /\@\@ \-\d+,\d+ \+(\d+),\d+ \@\@/g.exec(line)
+            if (range) {
+                lineNum = Number(range[1]) - 1
+            } else if (line.substr(0, 1) !== '-') {
+                lineNum++
+            }
+            if (find.test(line)) {
+                return cb(null, lineNum)
+            }
+        })
+    }
+}

--- a/lib/pull-request.js
+++ b/lib/pull-request.js
@@ -83,8 +83,13 @@ PullRequest.prototype.getPaths = function (callback) {
 
     github.getFiles(this.repo.data.owner.login, this.repo.data.name, this.data.number, function (err, files) {
         if (err) return callback(err);
-        this.exports.files = files;
-        callback(null, files);
+
+        github.getReviewComments(this.repo.data.owner.login, this.repo.data.name, this.data.number, function(err, comments) {
+            files = attachCommentsToFile.call(this, files, comments);
+            this.exports.files = files;
+            callback(null, files);
+        }.bind(this));
+
     }.bind(this));
 
 }
@@ -97,6 +102,24 @@ PullRequest.prototype.getCommits = function (callback) {
         callback(null, commits);
     }.bind(this));
 
+}
+
+// attach review comments to the related file
+function attachCommentsToFile(files, comments) {
+    return files.filter(function(file) {
+        return file.comments = comments.filter(function(comment) {
+            if (file.filename === comment.path) {
+                return comment.reply = attachCommentReply.call(this, comment);
+            }
+        }.bind(this));
+    }.bind(this));
+}
+
+// reply to a comment on a diff
+function attachCommentReply(comment) {
+    return function reply(body, callback) {
+        github.replyToReviewComment(this.repo.data.owner.login, this.repo.data.name, this.data.number, comment.id, body, callback);
+    }.bind(this);
 }
 
 module.exports = PullRequest;

--- a/lib/util/github.js
+++ b/lib/util/github.js
@@ -166,6 +166,7 @@ module.exports.getFiles = function (user, repo, number, page, files, callback) {
     github('/repos/:user/:repo/pulls/:number/files', options, function (err, result) {
         if (err) return callback(err);
         files = files.concat(result);
+        files.map(function(file) { return file.comment = commentOnFile(user, repo, number); });
         if (result.length === 50) module.exports.getFiles(user, repo, number, page + 1, files, callback);
         else callback(err, files);
     });
@@ -234,4 +235,19 @@ module.exports.commentOnIssue = function (user, repo, number, body, callback) {
         number: number,
         method: 'POST'
     }, callback);
+}
+
+function commentOnFile(user, repo, number) {
+    return function(body, position, callback) {
+        github('/repos/:user/:repo/pulls/:number/comments', {
+            user: user,
+            repo: repo,
+            number: number,
+            body: body,
+            position: position,
+            commit_id: this.sha,
+            path: this.filename,
+            method: 'POST'
+        }, callback);
+    }
 }

--- a/lib/util/github.js
+++ b/lib/util/github.js
@@ -146,6 +146,27 @@ module.exports.getComments = function (user, repo, number, page, comments, callb
     });
 };
 
+// fetches comments on all files in a pull request
+module.exports.getReviewComments = function (user, repo, number, callback) {
+    var page = 1;
+    var comments = [];
+    (function getReviewComments() {
+        var options = {
+            user: user,
+            repo: repo,
+            number: number,
+            page: page,
+            per_page: 50
+        };
+        github('/repos/:user/:repo/pulls/:number/comments', options, function (err, result) {
+            if (err) return callback(err);
+            comments = comments.concat(result);
+            page++;
+            if (result.length === options.per_page) getReviewComments();
+            else callback(err, comments);
+        });
+    }());
+};
 
 // fetches as many files as possible
 module.exports.getFiles = function (user, repo, number, page, files, callback) {
@@ -171,7 +192,6 @@ module.exports.getFiles = function (user, repo, number, page, files, callback) {
         else callback(err, files);
     });
 };
-
 
 // fetches as many commits as possible
 module.exports.getCommits = function (user, repo, number, page, commits, callback) {
@@ -233,6 +253,17 @@ module.exports.commentOnIssue = function (user, repo, number, body, callback) {
         repo: repo,
         body: body,
         number: number,
+        method: 'POST'
+    }, callback);
+}
+
+module.exports.replyToReviewComment = function(user, repo, number, comment_id, body, callback) {
+    github('/repos/:user/:repo/pulls/:number/comments', {
+        user: user,
+        repo: repo,
+        number: number,
+        body: body,
+        in_reply_to: comment_id,
         method: 'POST'
     }, callback);
 }


### PR DESCRIPTION
Fixes #2

Enables commenting on a line of a diff with:

``` javascript
pull.commentOnDiff({
    body: 'comments all up in ya code',
    commit_id: 'fd9e30492ae661058afe532ed6cfc0cb6d1d644f',
    path: 'relative/path/to/my/file.js',
    position: 4
})
```

Or if you know a comment id, you can reply with:

``` javascript
pull.commentOnDiff({
    body: 'ya I agree',
    in_reply_to: 123
})
```

Cheers!
