### PR TITLE
Fix github.getPullRequests

### DIFF
--- a/lib/util/github.js
+++ b/lib/util/github.js
@@ -91,7 +91,7 @@ module.exports.getPullRequests = function (user, repo, page, pulls, callback) {
     github('/repos/:user/:repo/pulls', options, function (err, result) {
         if (err) return callback(err);
         pulls = pulls.concat(result);
-        if (result.length === 50) module.exports.getIssues(user, repo, page + 1, pulls, callback);
+        if (result.length === 50) module.exports.getPullRequests(user, repo, page + 1, pulls, callback);
         else callback(err, pulls);
     });
 }


### PR DESCRIPTION
Recently have been running into an error testing on joyent/node where `this.data.diff_url` is undefined in `PullRequest.getDiff`. Found out it's because past page 1 on `github.getPullRequests` it switches to `github.getIssues`. This PR fixes that ;)
