### PR TITLE
Ignore runtime errors and only fail on assertion errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,4 @@ The following convenience methods are made available on all haunt objects. You c
 + issue.files[*].comment - (accepts an comment and line number) comment on a given line number in a diff of a pull-request
 + issue.files[*].comments[*].reply - (accepts a string) reply to a comment in a diff on a pull request
 + issue.reportFailures - generic test failure message, which notifies a user what failed based on mocha reporter.
++ issue.assertsFailed - only return assertion errors or false if no assertion errors occurred (will ignore runtime errors)

--- a/bin/haunt
+++ b/bin/haunt
@@ -52,7 +52,7 @@ console.log('Please provide your github credentials:'.yellow);
 
 prompt.start();
 
- var schema = {
+var schema = {
     properties: {
         username: {
             pattern: /^[a-zA-Z\s\-]+$/,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -28,7 +28,7 @@ module.exports = {
         },
 
         'after': function (pull) {
-            if (pull.reporter.stats.failures) {
+            if (pull.assertsFailed()) {
                 pull.reportFailures(pull.close.bind(pull))
             }
         }
@@ -53,7 +53,7 @@ module.exports = {
         },
 
         'after': function (issue) {
-            if (issue.reporter.stats.failures) {
+            if (issue.assertsFailed()) {
                 issue.reportFailures(issue.close.bind(issue))
             }
         }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -54,4 +54,12 @@ Helper.prototype.reportFailures = function (callback) {
     github.commentOnIssue(this.repo.owner.login, this.repo.name, this.number, body, callback);
 }
 
+// only return assertion errors, if none return false
+Helper.prototype.assertsFailed = function() {
+    var fails = this.reporter.failures.filter(function(err) {
+        if (err.err.name === "AssertionError") return err;
+    });
+    return fails.length > 0 ? fails : false;
+}
+
 module.exports = Helper;

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -85,7 +85,7 @@ Repo.prototype.spook = function (callback) {
             issue.exports.reporter = reporter;
 
             runner.run(function () {
-                if (reporter.stats.failures) {
+                if (issue.exports.assertsFailed()) {
                     total['failing-' + Repo.typeMap[type]]++;
                 }
                 next();


### PR DESCRIPTION
Currently if a test fails because of a runtime error such as a mistyped method name eg `issue.whoops()`, it will be assumed the test case has failed and trigger an action.

This PR adds the helper method `assertsFailed()` to only return assertion errors. This way users can only trigger an action if an assert fails, not just on any failure.
