### PR TITLE
Use ref instead of label when checking branches in basic example

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -8,11 +8,11 @@ module.exports = {
     'pull-requests': {
 
         'should always be made against -wip branches': function (pull) {
-            assert.ok(/\-wip$/.test(pull.base.label))
+            assert.ok(/\-wip$/.test(pull.base.ref))
         },
 
         'should always be made from feature branches': function (pull) {
-            assert.ok(pull.head.label != 'master')
+            assert.notEqual(pull.head.ref, 'master')
         },
 
         'should always include a unit test if changing js files': function (pull) {


### PR DESCRIPTION
Related to twitter/bootstrap#4241 Update the basic example to use `ref` as well for those copying the example.
