### PR TITLE
add support for multiple test structures

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ module.exports = {
 
             if (options.tests) {
                 repo.getTests = function (callback) {
-                    repo.tests = options.tests;
+                    repo.tests =  (options.tests instanceof Array) ?
+                        options.tests : new Array(options.tests);
                     callback(null, repo.tests);
                 }
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,11 +43,10 @@ module.exports = {
 
             repo.getData(function (err) {
                 if (err) throw err;
-                repo.spook();
+                repo.spook(callback);
             });
         });
 
         return this;
     }
-
 }

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -44,60 +44,71 @@ Repo.prototype.spook = function (callback) {
     var total = {
         'issues': this.issues.length,
         'pullRequests': this.pullRequests.length,
-        'failing-issues': 0,
-        'failing-pullRequests': 0
+        'totalBatches': this.tests.length
     }
 
     if (reporterType != 'Base') console.log('');
 
-    async.forEachSeries(Object.keys(this.tests), function (type, next) {
+    var batchTotal = {
+        'current-batch': 0
+    };
+    async.forEachSeries(this.tests, function (test, nextBatch) {
 
-        var issues = this[Repo.typeMap[type]];
+        batchTotal['current-batch']++;
+        batchTotal['failing-issues'] = 0;
+        batchTotal['failing-pullRequests'] = 0;
 
-        if (!issues.length) return next();
+        async.forEachSeries(Object.keys(test), function (type, next) {
 
-        async.forEachSeries(issues, function (issue, next) {
+            var issues = this[Repo.typeMap[type]];
 
-            reporterType != 'Base' && template.render('events/test-title', { type: type, url: issue.data.html_url });
+            if (!issues.length) return next();
 
-            var suite = new mocha.Suite(type, new mocha.Context);
+            async.forEachSeries(issues, function (issue, nextIssue) {
 
-            for (var key in this.tests[type]) {
+                reporterType != 'Base' && template.render('events/test-title', { type: type, url: issue.data.html_url });
 
-                var fn = this.tests[type][key];
+                var suite = new mocha.Suite(type, new mocha.Context);
 
-                switch (key) {
-                    case 'before':
-                        suite.beforeAll(fn.bind(fn, issue.exports));
-                        break;
-                    case 'after':
-                        suite.afterAll(fn.bind(fn, issue.exports));
-                        break;
-                    default:
-                        suite.addTest(new mocha.Test(key, fn.bind(fn, issue.exports)));
+                for (var key in test[type]) {
+
+                    var fn = test[type][key];
+
+                    switch (key) {
+                        case 'before':
+                            suite.beforeAll(fn.bind(fn, issue.exports));
+                            break;
+                        case 'after':
+                            suite.afterAll(fn.bind(fn, issue.exports));
+                            break;
+                        default:
+                            suite.addTest(new mocha.Test(key, fn.bind(fn, issue.exports)));
+                    }
+
                 }
 
+                var runner   = new mocha.Runner(suite);
+                var reporter = new mocha.reporters[reporterType](runner);
+
+                issue.exports.reporter = reporter;
+
+                runner.run(function () {
+                    if (reporter.stats.failures) {
+                        batchTotal['failing-' + Repo.typeMap[type]]++;
+                    }
+                    nextIssue();
+                });
+
+            }.bind(this), next);
+
+        }.bind(this), function () {
+            if (this.tests.length > 1) {
+                template.render('events/test-announce', { batch_total: total.totalBatches, batch_current: batchTotal['current-batch'] });
             }
-
-            var runner   = new mocha.Runner(suite);
-            var reporter = new mocha.reporters[reporterType](runner);
-
-            issue.exports.reporter = reporter;
-
-            runner.run(function () {
-                if (reporter.stats.failures) {
-                    total['failing-' + Repo.typeMap[type]]++;
-                }
-                next();
-            });
-
-        }.bind(this), next);
-
-    }.bind(this), function () {
-        template.render('events/test-summary', total)
-        callback();
-    });
-
+            template.render('events/test-summary', { total: total, batch_total: batchTotal });
+            nextBatch();
+        }.bind(this));
+    }.bind(this), callback);
 }
 
 Repo.prototype.getData = function (callback) {
@@ -154,7 +165,7 @@ Repo.prototype.getIssues = function (callback) {
     github.getIssues(this.data.owner.login, this.data.name, function (err, issues) {
         if (err) return callback(err);
 
-        if (!issues[0] || !issues[0].pull_request) {
+        if (!issues[0].pull_request) {
             issues = [];
         }
 

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -95,6 +95,7 @@ Repo.prototype.spook = function (callback) {
 
     }.bind(this), function () {
         template.render('events/test-summary', total)
+        callback();
     });
 
 }
@@ -153,7 +154,7 @@ Repo.prototype.getIssues = function (callback) {
     github.getIssues(this.data.owner.login, this.data.name, function (err, issues) {
         if (err) return callback(err);
 
-        if (!issues[0].pull_request) {
+        if (!issues[0] || !issues[0].pull_request) {
             issues = [];
         }
 

--- a/views/events/test-announce.mustache
+++ b/views/events/test-announce.mustache
@@ -1,0 +1,1 @@
+{{#yellow}}Batch {{batch_current}} out of {{batch_total}}{{/yellow}}

--- a/views/events/test-summary.mustache
+++ b/views/events/test-summary.mustache
@@ -1,2 +1,2 @@
-{{#magenta}}Total Failing Issues{{/magenta}} {{failing-issues}} of {{issues}}
-{{#magenta}}Total Failing Pull-Requests{{/magenta}} {{failing-pullRequests}} of {{pullRequests}}
+{{#magenta}}Total Failing Issues{{/magenta}} {{ batch_total.failing-issues }} of {{ total.issues }}
+{{#magenta}}Total Failing Pull-Requests{{/magenta}} {{ batch_total.failing-pullRequests }} of {{ total.pullRequests }}


### PR DESCRIPTION
Add possibility to set options.tests with an array of tests, each like the standard test waited

```
{
    'issues': { ... },
    'pull-requests': { ... }
}
```

It allow each group of test different "after" and "before" methods
