### PR TITLE
util/github: set User-Agent per API requirements

### DIFF
--- a/lib/util/github.js
+++ b/lib/util/github.js
@@ -9,6 +9,8 @@
 var request     = require('request');
 var querystring = require('querystring');
 
+var haunt = require('../../package.json');
+
 var github = function (path, options, callback) {
 
     var username = github.username;
@@ -46,6 +48,7 @@ var github = function (path, options, callback) {
     req.method  = method;
     req.headers = {
         'Host': 'api.github.com',
+        'User-Agent': 'haunt/v' + haunt.version,
         'Authorization': 'Basic ' + new Buffer(username + ':' + password).toString('base64')
     }
 


### PR DESCRIPTION
If this header is not set, the request is blocked.
See for more: https://developer.github.com/v3/#user-agent-required

Fixes #18.
