### PR TITLE
repo: fix accessing property on possible null value in getIssues

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -153,7 +153,7 @@ Repo.prototype.getIssues = function (callback) {
     github.getIssues(this.data.owner.login, this.data.name, function (err, issues) {
         if (err) return callback(err);
 
-        if (!issues[0].pull_request) {
+        if (!(issues[0] || {}).pull_request) {
             issues = [];
         }
 


### PR DESCRIPTION
If `issues[0]` returns `null` or `undefined`, accessing the `pull_request` property
will cause it to fail.

``` text
TypeError: Cannot read property 'pull_request' of undefined
    at null.<anonymous> (/Users/parker/jekyll/haunt/node_modules/haunt/lib/repo.js:156:23)
```
